### PR TITLE
Improve save_colorscheme to be deterministic

### DIFF
--- a/gui/helpers.py
+++ b/gui/helpers.py
@@ -300,7 +300,7 @@ def save_colorscheme(preset_name, colorscheme):
         with open(path, 'w') as f:
             if 'NAME' not in colorscheme:
                 f.write("NAME={}\n".format(preset_name))
-            for key in colorscheme.keys():
+            for key in sorted(colorscheme.keys()):
                 f.write("{}={}\n".format(
                     key, colorscheme[key]
                 ))


### PR DESCRIPTION
Previously, `save_colorscheme` would write colorscheme keys in a random order, so that each new instance of oomox will save the same colorscheme values in different orders. If a user would like to keep their schemes version-controlled, this makes diffs messy.

Instead, when saving colorscheme keys, we write them in sorted order so that they can be sensibly version-controlled.