### PR TITLE
fix(scripts/mix.sh): fix floating-point truncation on non-C locales

### DIFF
--- a/scripts/mix.sh
+++ b/scripts/mix.sh
@@ -5,7 +5,7 @@ mix_channel() {
 	value1=${1}
 	value2=${2}
 	ratio=${3}
-	result=$(printf '%.0f' $(echo "ibase=16; ${value1} * ${ratio} + ${value2} * (1 - ${ratio})" | bc))
+	result=$(echo "scale=0; ibase=16; (${value1} * ${ratio} + ${value2} * (1 - ${ratio}))/1" | bc)
 	if [[ ${result} -lt 0 ]] ; then
 		result=0
 	fi


### PR DESCRIPTION
Some locales use a different fractional separator than `.`, like French which uses `,` (e.g. `123,4`). This confuses `printf` which doesn't understand `bc`'s output and leads to it falling back on `0` as the value.

Fix this by performing the truncation directly in `bc` itself.

---
Alternatively you could set `LC_NUMERIC=C` in the `printf` sub-shell, but it seems best to truncate in `bc` as it's possible.