### PR TITLE
feat(change_colors, gui): add support for theming the caret

### DIFF
--- a/change_color.sh
+++ b/change_color.sh
@@ -110,6 +110,9 @@ ICONS_LIGHT="${ICONS_LIGHT-$SEL_BG}"
 ICONS_MEDIUM="${ICONS_MEDIUM-$medium_base_fallback}"
 ICONS_DARK="${ICONS_DARK-$dark_stroke_fallback}"
 
+CARET1_FG="${CARET1_FG-$TXT_FG}"
+CARET2_FG="${CARET2_FG-$TXT_FG}"
+CARET_SIZE="${CARET_SIZE-0.04}"
 
 OUTPUT_THEME_NAME="${OUTPUT_THEME_NAME-oomox-$THEME}"
 DEST_PATH="$HOME/.themes/${OUTPUT_THEME_NAME/\//-}"
@@ -154,6 +157,9 @@ for FILEPATH in "${PATHLIST[@]}"; do
 		-e 's/%ICONS_LIGHT%/'"$ICONS_LIGHT"'/g' \
 		-e 's/%ICONS_LIGHT_FOLDER%/'"$ICONS_LIGHT_FOLDER"'/g' \
 		-e 's/%OUTPUT_THEME_NAME%/'"$OUTPUT_THEME_NAME"'/g' \
+		-e 's/%CARET1_FG%/'"$CARET1_FG"'/g' \
+		-e 's/%CARET2_FG%/'"$CARET2_FG"'/g' \
+		-e 's/%CARET_SIZE%/'"$CARET_SIZE"'/g' \
 		{} \; ;
 done
 

--- a/gui/preview.py
+++ b/gui/preview.py
@@ -18,6 +18,32 @@ class ThemePreview(Gtk.Grid):
         elif value == self.FG:
             return widget.override_color(state, color)
 
+    def update_preview_carets(self, colorscheme):
+        css_provider_caret = Gtk.CssProvider()
+        css_provider_caret.load_from_data((
+            (Gtk.get_minor_version() >= 20 and """
+            * {{
+                caret-color: #{primary_caret_color};
+                -gtk-secondary-caret-color: #{secondary_caret_color};
+                -GtkWidget-cursor-aspect-ratio: {caret_aspect_ratio};
+            }}
+            """ or """
+            * {{
+                -GtkWidget-cursor-color: #{primary_caret_color};
+                -GtkWidget-secondary-cursor-color: #{secondary_caret_color};
+                -GtkWidget-cursor-aspect-ratio: {caret_aspect_ratio};
+            }}
+            """).format(
+                primary_caret_color=colorscheme['CARET1_FG'],
+                secondary_caret_color=colorscheme['CARET2_FG'],
+                caret_aspect_ratio=colorscheme['CARET_SIZE']
+        )).encode('ascii'))
+        Gtk.StyleContext.add_provider(
+            self.entry.get_style_context(),
+            css_provider_caret,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+
     def update_preview_gradients(self, colorscheme):
         gradient = colorscheme['GRADIENT']
         for widget, color in zip(
@@ -209,6 +235,7 @@ class ThemePreview(Gtk.Grid):
         self.update_preview_gradients(colorscheme)
         self.update_preview_roundness(colorscheme)
         self.update_preview_icons(colorscheme)
+        self.update_preview_carets(colorscheme)
 
     def __init__(self):
         super().__init__(row_spacing=6, column_spacing=6)

--- a/gui/theme_model.py
+++ b/gui/theme_model.py
@@ -118,6 +118,29 @@ theme_model = [
 
     {
         'type': 'separator',
+        'display_name': 'Text input caret'
+    },
+    {
+        'key': 'CARET1_FG',
+        'type': 'color',
+        'fallback_key': 'TXT_FG',
+        'display_name': 'Primary caret color'
+    },
+    {
+        'key': 'CARET2_FG',
+        'type': 'color',
+        'fallback_key': 'TXT_FG',
+        'display_name': 'Secondary caret color'
+    },
+    {
+        'key': 'CARET_SIZE',
+        'type': 'float',
+        'fallback_value': 0.04,  # GTK's default
+        'display_name': 'Caret aspect ratio'
+    },
+
+    {
+        'type': 'separator',
         'display_name': 'Iconset'
     },
 

--- a/src/gtk-2.0/gtkrc
+++ b/src/gtk-2.0/gtkrc
@@ -1,11 +1,15 @@
 # Oomox GTK Theme (Numix Fork)
 
 gtk-color-scheme =
-"base_color:#%TXT_BG%\nbg_color:#%BG%\ntooltip_bg_color:#%BG%\nselected_bg_color:#%SEL_BG%\ntext_color:#%TXT_FG%\nfg_color:#%FG%\ntooltip_fg_color:#%FG%\nselected_fg_color:#%SEL_FG%\nmenubar_bg_color:#%MENU_BG%\nmenubar_fg_color:#%MENU_FG%\ntoolbar_bg_color:#%BG%\ntoolbar_fg_color:#%FG%\nmenu_bg_color:#%MENU_BG%\nmenu_fg_color:#%MENU_FG%\npanel_bg_color:#%BG%\npanel_fg_color:#%FG%\nlink_color:#%SEL_BG%\nbtn_bg_color:#%BTN_BG%\nbtn_fg_color:#%BTN_FG%\ntitlebar_bg_color:#%MENU_BG%\ntitlebar_fg_color:#%MENU_FG%\n"
+"base_color:#%TXT_BG%\nbg_color:#%BG%\ntooltip_bg_color:#%BG%\nselected_bg_color:#%SEL_BG%\ntext_color:#%TXT_FG%\nfg_color:#%FG%\ntooltip_fg_color:#%FG%\nselected_fg_color:#%SEL_FG%\nmenubar_bg_color:#%MENU_BG%\nmenubar_fg_color:#%MENU_FG%\ntoolbar_bg_color:#%BG%\ntoolbar_fg_color:#%FG%\nmenu_bg_color:#%MENU_BG%\nmenu_fg_color:#%MENU_FG%\npanel_bg_color:#%BG%\npanel_fg_color:#%FG%\nlink_color:#%SEL_BG%\nbtn_bg_color:#%BTN_BG%\nbtn_fg_color:#%BTN_FG%\ntitlebar_bg_color:#%MENU_BG%\ntitlebar_fg_color:#%MENU_FG%\nprimary_caret_color:#%CARET1_FG%\nsecondary_caret_color:#%CARET2_FG%\n"
 # Default Style
 
 style "murrine-default" {
 	GtkArrow::arrow-scaling= 0.6
+
+	GtkWidget::cursor_color = @primary_caret_color
+	GtkWidget::secondary_cursor_color = @secondary_caret_color
+	GtkWidget::cursor_aspect_ratio = %CARET_SIZE%
 
 	GtkButton::child-displacement-x = 0
 	GtkButton::child-displacement-y = 0

--- a/src/gtk-3.0/scss/_global.scss
+++ b/src/gtk-3.0/scss/_global.scss
@@ -24,6 +24,11 @@ $dark_fg_color: #%MENU_FG%;
 $dark_shadow: #000;
 $light_shadow: #fff;
 
+// caret
+$primary_caret_color: #%CARET1_FG%;
+$secondary_caret_color: #%CARET2_FG%;
+$caret_aspect_ratio: %CARET_SIZE%;
+
 // white and black
 $black: #000;
 $white: #fff;

--- a/src/gtk-3.0/scss/widgets/_base.scss
+++ b/src/gtk-3.0/scss/widgets/_base.scss
@@ -11,6 +11,10 @@
     -GtkWindow-resize-grip-width: 0;
     -WnckTasklist-fade-overlay-rect: 0;
 
+    -GtkWidget-cursor-color: $primary_caret_color;
+    -GtkWidget-secondary-cursor-color: $secondary_caret_color;
+    -GtkWidget-cursor-aspect-ratio: $caret_aspect_ratio;
+
     outline-color: alpha($selected_bg_color, .5);
     outline-style: dashed;
     outline-width: 1px;

--- a/src/gtk-3.20/scss/_global.scss
+++ b/src/gtk-3.20/scss/_global.scss
@@ -32,6 +32,11 @@ $dark_fg_color: #%MENU_FG%;
 $dark_shadow: shade($fg_color, .2);
 $light_shadow: lighten($bg_color, .4);
 
+// caret
+$primary_caret_color: #%CARET1_FG%;
+$secondary_caret_color: #%CARET2_FG%;
+$caret_aspect_ratio: %CARET_SIZE%;
+
 // white and black
 $black: #000;
 $white: #fff;

--- a/src/gtk-3.20/scss/widgets/_base.scss
+++ b/src/gtk-3.20/scss/widgets/_base.scss
@@ -7,6 +7,8 @@
     -GtkWindow-resize-grip-width: 0;
     -WnckTasklist-fade-overlay-rect: 0;
 
+    -GtkWidget-cursor-aspect-ratio: $caret_aspect_ratio;
+
     outline-color: alpha($selected_bg_color, .5);
     outline-style: dashed;
     outline-width: 1px;

--- a/src/gtk-3.20/scss/widgets/_entry.scss
+++ b/src/gtk-3.20/scss/widgets/_entry.scss
@@ -159,7 +159,8 @@
     padding: $spacing;
 
     color: $fg;
-    caret-color: $fg;
+    caret-color: $primary_caret_color;
+    -gtk-secondary-caret-color: $secondary_caret_color;
 
     &:focus, &:active { border-color: border_focus($border); }
 

--- a/src/gtk-3.20/scss/widgets/_view.scss
+++ b/src/gtk-3.20/scss/widgets/_view.scss
@@ -7,6 +7,8 @@
     %view {
         color: $text_color;
         background-color: $base_color;
+        caret-color: $primary_caret_color;
+        -gtk-secondary-caret-color: $secondary_caret_color;
 
         &:backdrop {
             color: $backdrop_text_color;


### PR DESCRIPTION
Changing the caret size and colors is especially useful for accessibility purposes, e.g. for people with low vision having a larger and more outstanding caret is best.