### PR TITLE
fix(gui): fix typo breaking Python 3.4 support

### DIFF
--- a/gui/helpers.py
+++ b/gui/helpers.py
@@ -275,10 +275,10 @@ class ImageContainer(Gtk.Container):
 class ImageButton(Gtk.Button, ImageContainer):
     def __init__(self, *args, **kwargs):
         Gtk.Button.__init__(self)
-        ImageContainer.__init__(self, *args, *kwargs)
+        ImageContainer.__init__(self, *args, **kwargs)
 
 
 class ImageMenuButton(Gtk.MenuButton, ImageContainer):
     def __init__(self, *args, **kwargs):
         Gtk.MenuButton.__init__(self)
-        ImageContainer.__init__(self, *args, *kwargs)
+        ImageContainer.__init__(self, *args, **kwargs)


### PR DESCRIPTION
I introduced it in 40260ae386a19bf7a1adf0bcb0af9c027eb976f6, sorry

Kind of weird Python 3.5 liked it.  Doesn't affect much otherwise as currently no keyword arguments are used.