### PR TITLE
fix(gui): support older python3-gi

### DIFF
--- a/gui/main.py
+++ b/gui/main.py
@@ -317,8 +317,9 @@ class AppWindow(Gtk.ApplicationWindow):
         menu_button = ImageMenuButton("open-menu-symbolic")
         menu_button.set_use_popover(True)
         menu_button.set_menu_model(menu)
-        self.add_action(Gio.PropertyAction.new(win.menu.name,
-                                               menu_button, "active"))
+        self.add_action(Gio.PropertyAction(name=win.menu.name,
+                                           object=menu_button,
+                                           property_name="active"))
         self.headerbar.pack_end(menu_button)
 
         export_icons_button = Gtk.Button(label="Export _icons",


### PR DESCRIPTION
Gio.PropertyAction.new() has a bug on older python3-gi, at least up to
3.14, which leads to https://bugzilla.gnome.org/show_bug.cgi?id=683599.