### PR TITLE
GUI: Add internationalization support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ __pycache__
 oomox/
 pkg/
 *.tar.xz
+
+# gettext stuff
+locale/
+po/oomox.pot
+po/*.mo

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -39,6 +39,7 @@ pkgver() {
 }
 
 package() {
+	make -C oomox -f po.mk install
 	mkdir -p ${pkgdir}/opt/oomox
 	mv ./oomox/* ${pkgdir}/opt/oomox
 	mkdir -p ${pkgdir}/usr/bin/

--- a/gui/colors_list.py
+++ b/gui/colors_list.py
@@ -162,7 +162,8 @@ class OomoxColorSelectionDialog(Gtk.ColorSelectionDialog):
         self.gtk_color = gtk_color
         self.parent_window = parent
 
-        Gtk.ColorSelectionDialog.__init__(self, "Choose a color...", parent, 0)
+        Gtk.ColorSelectionDialog.__init__(self, _("Choose a color..."),
+                                          parent, 0)
         self.set_transient_for(parent)
         self.props.color_selection.set_has_palette(True)
 
@@ -301,7 +302,7 @@ class ThemeColorsList(Gtk.Box):
         self.listbox.foreach(lambda x: self.listbox.remove(x))
         if "NOGUI" in self.theme:
             row = Gtk.ListBoxRow()
-            row.add(Gtk.Label("Can't be edited in GUI"))
+            row.add(Gtk.Label(_("Can't be edited in GUI")))
             self.listbox.add(row)
         else:
             for theme_value in theme_model:
@@ -362,6 +363,6 @@ class ThemeColorsList(Gtk.Box):
         scrolled.add(self.listbox)
 
         theme_edit_label = Gtk.Label()
-        theme_edit_label.set_text("Edit:")
+        theme_edit_label.set_text(_("Edit:"))
         self.pack_start(theme_edit_label, False, False, 0)
         self.pack_start(scrolled, True, True, 0)

--- a/gui/export.py
+++ b/gui/export.py
@@ -19,11 +19,11 @@ class ExportDialog(Gtk.Dialog):
         self.spinner.destroy()
 
         label = CenterLabel(
-            "Something went wrong :("
+            _("Something went wrong :(")
         )
         label.set_alignment(0.5, 0.5)
 
-        button = Gtk.Button(label="Dismiss")
+        button = Gtk.Button(label=_("Dismiss"))
         button.connect("clicked", self._close_button_callback)
 
         self.under_log_box.add(label)
@@ -36,12 +36,12 @@ class ExportDialog(Gtk.Dialog):
     def _adj_changed(self, adj):
         adj.set_value(adj.get_upper() - adj.get_page_size())
 
-    def __init__(self, parent, headline="Exporting..."):
+    def __init__(self, parent, headline=_("Exporting...")):
         Gtk.Dialog.__init__(self, headline, parent, 0)
         self.set_default_size(150, 80)
 
         self.label = CenterLabel(
-            "Please wait while\nnew colorscheme will be created"
+            _("Please wait while\nnew colorscheme will be created")
         )
 
         self.spinner = Gtk.Spinner()
@@ -195,32 +195,32 @@ class SpotifyExportDialog(ExportDialog):
         self.spinner.stop()
         self.apply_button.destroy()
 
-        self.label.set_text("Theme applied successfully")
+        self.label.set_text(_("Theme applied successfully"))
 
-        button = Gtk.Button(label="OK")
+        button = Gtk.Button(label=_("OK"))
         button.connect("clicked", self._close_button_callback)
 
         self.under_log_box.add(button)
         self.show_all()
 
     def __init__(self, parent, theme_path):
-        ExportDialog.__init__(self, parent, "Spotify options")
+        ExportDialog.__init__(self, parent, _("Spotify options"))
         self.theme_path = theme_path
 
         # self.set_default_size(180, 120)
         self.spinner.stop()
-        self.label.set_text("This functionality is still in BETA")
+        self.label.set_text(_("This functionality is still in BETA"))
 
         self.options_box = Gtk.Box(
             orientation=Gtk.Orientation.VERTICAL, spacing=5
         )
         self.options_box.set_margin_bottom(10)
 
-        self.font_checkbox = Gtk.CheckButton(label="Normalize font weight")
+        self.font_checkbox = Gtk.CheckButton(label=_("Normalize font weight"))
         self.options_box.add(self.font_checkbox)
 
         hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
-        spotify_path_label = Gtk.Label('Spotify path:')
+        spotify_path_label = Gtk.Label(_('Spotify path:'))
         self.spotify_path_entry = Gtk.Entry(text=DEFAULT_SPOTIFY_PATH)
         hbox.add(spotify_path_label)
         hbox.add(self.spotify_path_entry)
@@ -228,7 +228,7 @@ class SpotifyExportDialog(ExportDialog):
 
         self.under_log_box.add(self.options_box)
 
-        self.apply_button = Gtk.Button(label="Apply")
+        self.apply_button = Gtk.Button(label=_("Apply"))
         self.apply_button.connect("clicked", lambda x: self.do_export())
         self.under_log_box.add(self.apply_button)
 

--- a/gui/main.py
+++ b/gui/main.py
@@ -5,6 +5,9 @@ import gi
 gi.require_version('Gtk', '3.0')  # noqa
 from gi.repository import Gtk, GObject, Gio
 
+import gettext
+gettext.install('oomox')
+
 from .helpers import (
     user_theme_dir, is_user_colorscheme, is_colorscheme_exists,
     mkdir_p,
@@ -31,8 +34,8 @@ class NewDialog(Gtk.Dialog):
         self.destroy()
 
     def __init__(self, parent,
-                 title="New theme",
-                 text="Please input new theme name:"):
+                 title=_("New theme"),
+                 text=_("Please input new theme name:")):
         Gtk.Dialog.__init__(self, title, parent, 0)
 
         self.set_default_size(150, 100)
@@ -45,8 +48,8 @@ class NewDialog(Gtk.Dialog):
         box.add(label)
         box.add(self.entry)
 
-        cancel_button = self.add_button("_Cancel", Gtk.ResponseType.CANCEL)
-        ok_button = self.add_button("_OK", Gtk.ResponseType.OK)
+        cancel_button = self.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        ok_button = self.add_button(_("_OK"), Gtk.ResponseType.OK)
 
         self.set_default_response(Gtk.ResponseType.OK)
 
@@ -56,7 +59,7 @@ class NewDialog(Gtk.Dialog):
 class RenameDialog(NewDialog):
 
     def __init__(self, parent):
-        NewDialog.__init__(self, parent, title="Rename theme")
+        NewDialog.__init__(self, parent, title=_("Rename theme"))
 
 
 class YesNoDialog(Gtk.Dialog):
@@ -66,7 +69,7 @@ class YesNoDialog(Gtk.Dialog):
 
     def __init__(self, parent,
                  title="",
-                 text="Are you sure?",
+                 text=_("Are you sure?"),
                  default_response=Gtk.ResponseType.NO):
         Gtk.Dialog.__init__(self, title, parent, 0)
         self.set_default_size(150, 100)
@@ -75,8 +78,8 @@ class YesNoDialog(Gtk.Dialog):
         box = self.get_content_area()
         box.add(label)
 
-        cancel_button = self.add_button("_No", Gtk.ResponseType.NO)
-        ok_button = self.add_button("_Yes", Gtk.ResponseType.YES)
+        cancel_button = self.add_button(_("_No"), Gtk.ResponseType.NO)
+        ok_button = self.add_button(_("_Yes"), Gtk.ResponseType.YES)
 
         self.set_default_response(default_response)
 
@@ -87,17 +90,17 @@ class UnsavedDialog(YesNoDialog):
 
     def __init__(self, parent):
         YesNoDialog.__init__(self, parent,
-                             "Unsaved changes",
-                             "There are unsaved changes.\nSave them?")
+                             _("Unsaved changes"),
+                             _("There are unsaved changes.\nSave them?"))
 
 
 class RemoveDialog(YesNoDialog):
 
     def __init__(self, parent):
         YesNoDialog.__init__(
-            self, parent, "Remove theme",
-            "Are you sure you want to delete the colorscheme?\n"
-            "This can not be undone."
+            self, parent, _("Remove theme"),
+            _("Are you sure you want to delete the colorscheme?\n"
+              "This can not be undone.")
         )
 
 
@@ -183,7 +186,8 @@ class AppWindow(Gtk.ApplicationWindow):
         else:
             dialog = Gtk.MessageDialog(
                 self, 0, Gtk.MessageType.WARNING,
-                Gtk.ButtonsType.OK, "Colorscheme with such name already exists"
+                Gtk.ButtonsType.OK,
+                _("Colorscheme with such name already exists")
             )
             dialog.run()
             dialog.destroy()
@@ -277,29 +281,30 @@ class AppWindow(Gtk.ApplicationWindow):
     def _init_headerbar(self):
         self.headerbar = Gtk.HeaderBar()
         self.headerbar.set_show_close_button(True)
-        self.headerbar.props.title = "Oo-mox GUI"
+        self.headerbar.props.title = _("Oo-mox GUI")
 
         # @TODO:
-        # new_button = ImageButton("text-x-generic-symbolic", "Create new theme")  # noqa
+        # new_button = ImageButton("text-x-generic-symbolic", _("Create new theme"))  # noqa
         # self.headerbar.pack_start(new_button)
 
-        clone_button = ImageButton("edit-copy-symbolic", "Clone current theme")
+        clone_button = ImageButton("edit-copy-symbolic",
+                                   _("Clone current theme"))
         self.attach_action(clone_button, win.clone)
         self.headerbar.pack_start(clone_button)
 
-        save_button = ImageButton("document-save-symbolic", "Save theme")
+        save_button = ImageButton("document-save-symbolic", _("Save theme"))
         self.attach_action(save_button, win.save)
         self.headerbar.pack_start(save_button)
 
         rename_button = ImageButton(
             # "preferences-desktop-font-symbolic", "Rename theme"
-            "pda-symbolic", "Rename theme"
+            "pda-symbolic", _("Rename theme")
         )
         self.attach_action(rename_button, win.rename)
         self.headerbar.pack_start(rename_button)
 
         remove_button = ImageButton(
-            "edit-delete-symbolic", "Remove theme"
+            "edit-delete-symbolic", _("Remove theme")
         )
         self.attach_action(remove_button, win.remove)
         self.headerbar.pack_start(remove_button)
@@ -308,10 +313,10 @@ class AppWindow(Gtk.ApplicationWindow):
 
         menu = Gio.Menu()
         """
-        menu.append_item(Gio.MenuItem.new("_Export icon theme",
+        menu.append_item(Gio.MenuItem.new(_("_Export icon theme"),
                                           win.export_icons))
         """
-        menu.append_item(Gio.MenuItem.new("Apply Spotif_y theme",
+        menu.append_item(Gio.MenuItem.new(_("Apply Spotif_y theme"),
                                           win.export_spotify))
 
         menu_button = ImageMenuButton("open-menu-symbolic")
@@ -322,14 +327,15 @@ class AppWindow(Gtk.ApplicationWindow):
                                            property_name="active"))
         self.headerbar.pack_end(menu_button)
 
-        export_icons_button = Gtk.Button(label="Export _icons",
+        export_icons_button = Gtk.Button(label=_("Export _icons"),
                                          use_underline=True,
-                                         tooltip_text="Export icon theme")
+                                         tooltip_text=_("Export icon theme"))
         self.attach_action(export_icons_button, win.export_icons)
         self.headerbar.pack_end(export_icons_button)
 
-        export_button = Gtk.Button(label="_Export theme", use_underline=True,
-                                   tooltip_text="Export GTK theme")
+        export_button = Gtk.Button(label=_("_Export theme"),
+                                   use_underline=True,
+                                   tooltip_text=_("Export GTK theme"))
         self.attach_action(export_button, win.export_theme)
         self.headerbar.pack_end(export_button)
 
@@ -367,7 +373,7 @@ class AppWindow(Gtk.ApplicationWindow):
         if focus_on_path:
             self.presets_list.focus_preset_by_filepath(focus_on_path)
 
-    def __init__(self, application=None, title="Oo-mox GUI"):
+    def __init__(self, application=None, title=_("Oo-mox GUI")):
         Gtk.ApplicationWindow.__init__(self, application=application, title=title)
         self.colorscheme = {}
         mkdir_p(user_theme_dir)

--- a/gui/main.py
+++ b/gui/main.py
@@ -6,7 +6,9 @@ gi.require_version('Gtk', '3.0')  # noqa
 from gi.repository import Gtk, GObject, Gio
 
 import gettext
-gettext.install('oomox')
+_localedir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                          '..', 'locale')
+gettext.install('oomox', _localedir)
 
 from .helpers import (
     user_theme_dir, is_user_colorscheme, is_colorscheme_exists,

--- a/gui/presets_list.py
+++ b/gui/presets_list.py
@@ -109,6 +109,6 @@ class ThemePresetsList(Gtk.Box):
         scrolled.add(self.treeview)
 
         presets_list_label = Gtk.Label()
-        presets_list_label.set_text("Presets:")
+        presets_list_label.set_text(_("Presets:"))
         self.pack_start(presets_list_label, False, False, 0)
         self.pack_start(scrolled, True, True, 0)

--- a/gui/preview.py
+++ b/gui/preview.py
@@ -261,7 +261,7 @@ class ThemePreview(Gtk.Grid):
         menu = Gtk.Menu()
         for i in range(0, n_items):
             sensitive = (i + 1) % 3 != 0
-            label = 'Item {id}' if sensitive else 'Insensitive Item {id}'
+            label = _('Item {id}') if sensitive else _('Insensitive Item {id}')
             item = Gtk.MenuItem(label=label.format(id=i + 1),
                                 sensitive=sensitive)
             menu.append(item)
@@ -270,7 +270,7 @@ class ThemePreview(Gtk.Grid):
         return menu
 
     def _init_widgets(self):
-        preview_label = Gtk.Label("Preview:")
+        preview_label = Gtk.Label(_("Preview:"))
         self.bg = Gtk.Grid(row_spacing=6, column_spacing=6)
         self.attach(preview_label, 1, 1, 3, 1)
         self.attach_next_to(self.bg, preview_label,
@@ -280,26 +280,26 @@ class ThemePreview(Gtk.Grid):
 
         self.headerbar = Gtk.HeaderBar()
         self.headerbar.set_show_close_button(True)
-        self.headerbar.props.title = "Headerbar"
-        self.headerbar_button = Gtk.Button(label="   Button   ")
+        self.headerbar.props.title = _("Headerbar")
+        self.headerbar_button = Gtk.Button(label="   %s   " % _("Button"))
         self.headerbar.pack_end(self.headerbar_button)
 
         self.menubar = Gtk.MenuBar()
-        self.menuitem1 = Gtk.MenuItem(label='File')
+        self.menuitem1 = Gtk.MenuItem(label=_('File'))
         self.menuitem1.set_submenu(self.create_menu(3, True))
         self.menubar.append(self.menuitem1)
-        self.menuitem2 = Gtk.MenuItem(label='Edit')
+        self.menuitem2 = Gtk.MenuItem(label=_('Edit'))
         self.menuitem2.set_submenu(self.create_menu(6, True))
         self.menubar.append(self.menuitem2)
 
         self.headerbox.pack_start(self.headerbar, True, True, 0)
         self.headerbox.pack_start(self.menubar, True, True, 0)
 
-        self.label = Gtk.Label("This is a label.")
-        self.sel_label = Gtk.Label("Selected item.")
-        self.entry = Gtk.Entry(text="Text entry.")
+        self.label = Gtk.Label(_("This is a label."))
+        self.sel_label = Gtk.Label(_("Selected item."))
+        self.entry = Gtk.Entry(text=_("Text entry."))
 
-        self.button = Gtk.Button(label="Click-click")
+        self.button = Gtk.Button(label=_("Click-click"))
 
         self.icon_preview_listbox = Gtk.ListBox()
         self.icon_preview_listbox.set_selection_mode(Gtk.SelectionMode.NONE)

--- a/gui/theme_model.py
+++ b/gui/theme_model.py
@@ -8,140 +8,140 @@ theme_model = [
     {
         'key': 'BG',
         'type': 'color',
-        'display_name': 'Background'
+        'display_name': _('Background')
     },
     {
         'key': 'FG',
         'type': 'color',
-        'display_name': 'Foreground/text'
+        'display_name': _('Foreground/text')
     },
     {
         'key': 'MENU_BG',
         'type': 'color',
-        'display_name': 'Menu/toolbar background'
+        'display_name': _('Menu/toolbar background')
     },
     {
         'key': 'MENU_FG',
         'type': 'color',
-        'display_name': 'Menu/toolbar text'
+        'display_name': _('Menu/toolbar text')
     },
     {
         'key': 'SEL_BG',
         'type': 'color',
-        'display_name': 'Selection highlight'
+        'display_name': _('Selection highlight')
     },
     {
         'key': 'SEL_FG',
         'type': 'color',
-        'display_name': 'Selection text'
+        'display_name': _('Selection text')
     },
     {
         'key': 'TXT_BG',
         'type': 'color',
-        'display_name': 'Textbox background'
+        'display_name': _('Textbox background')
     },
     {
         'key': 'TXT_FG',
         'type': 'color',
-        'display_name': 'Textbox text'
+        'display_name': _('Textbox text')
     },
     {
         'key': 'BTN_BG',
         'type': 'color',
-        'display_name': 'Button background'
+        'display_name': _('Button background')
     },
     {
         'key': 'BTN_FG',
         'type': 'color',
-        'display_name': 'Button text'
+        'display_name': _('Button text')
     },
     {
         'key': 'HDR_BTN_BG',
         'fallback_key': 'BTN_BG',
         'type': 'color',
-        'display_name': 'Header button background'
+        'display_name': _('Header button background')
     },
     {
         'key': 'HDR_BTN_FG',
         'fallback_key': 'BTN_FG',
         'type': 'color',
-        'display_name': 'Header button text'
+        'display_name': _('Header button text')
     },
     {
         'key': 'WM_BORDER_FOCUS',
         'fallback_key': 'MENU_BG',
         'type': 'color',
-        'display_name': 'Focused window border'
+        'display_name': _('Focused window border')
     },
     {
         'key': 'WM_BORDER_UNFOCUS',
         'fallback_key': 'MENU_BG',
         'type': 'color',
-        'display_name': 'Unfocused window border'
+        'display_name': _('Unfocused window border')
     },
 
     {
         'type': 'separator',
-        'display_name': 'Theme options'
+        'display_name': _('Theme options')
     },
 
     {
         'key': 'ROUNDNESS',
         'type': 'int',
         'fallback_value': 2,
-        'display_name': 'Roundness'
+        'display_name': _('Roundness')
     },
     {
         'key': 'SPACING',
         'type': 'int',
         'fallback_value': 3,
-        'display_name': '(GTK3) Spacing'
+        'display_name': _('(GTK3) Spacing')
     },
     {
         'key': 'GRADIENT',
         'type': 'float',
         'fallback_value': 0.0,
-        'display_name': '(GTK3) Gradient'
+        'display_name': _('(GTK3) Gradient')
     },
     {
         'key': 'GTK3_GENERATE_DARK',
         'type': 'bool',
         'fallback_value': True,
-        'display_name': '(GTK3) Add dark variant'
+        'display_name': _('(GTK3) Add dark variant')
     },
     {
         'key': 'GTK2_HIDPI',
         'type': 'bool',
         'fallback_value': False,
-        'display_name': '(GTK2) HiDPI'
+        'display_name': _('(GTK2) HiDPI')
     },
 
     {
         'type': 'separator',
-        'display_name': 'Text input caret'
+        'display_name': _('Text input caret')
     },
     {
         'key': 'CARET1_FG',
         'type': 'color',
         'fallback_key': 'TXT_FG',
-        'display_name': 'Primary caret color'
+        'display_name': _('Primary caret color')
     },
     {
         'key': 'CARET2_FG',
         'type': 'color',
         'fallback_key': 'TXT_FG',
-        'display_name': 'Secondary caret color'
+        'display_name': _('Secondary caret color')
     },
     {
         'key': 'CARET_SIZE',
         'type': 'float',
         'fallback_value': 0.04,  # GTK's default
-        'display_name': 'Caret aspect ratio'
+        'display_name': _('Caret aspect ratio')
     },
 
     {
         'type': 'separator',
-        'display_name': 'Iconset'
+        'display_name': _('Iconset')
     },
 
     {
@@ -157,52 +157,52 @@ theme_model = [
             }
         ],
         'fallback_value': 'gnome_colors',
-        'display_name': 'Icons style'
+        'display_name': _('Icons style')
     },
     {
         'key': 'ICONS_ARCHDROID',
         'type': 'color',
         'fallback_key': 'SEL_BG',
-        'display_name': 'Icons color',
+        'display_name': _('Icons color'),
         'filter': create_value_filter('ICONS_STYLE', 'archdroid')
     },
     {
         'key': 'ICONS_LIGHT_FOLDER',
         'type': 'color',
         'fallback_key': 'SEL_BG',
-        'display_name': 'Light base (folders)',
+        'display_name': _('Light base (folders)'),
         'filter': create_value_filter('ICONS_STYLE', 'gnome_colors')
     },
     {
         'key': 'ICONS_LIGHT',
         'fallback_key': 'SEL_BG',
         'type': 'color',
-        'display_name': 'Light base',
+        'display_name': _('Light base'),
         'filter': create_value_filter('ICONS_STYLE', 'gnome_colors')
     },
     {
         'key': 'ICONS_MEDIUM',
         'type': 'color',
         'fallback_key': 'BTN_BG',
-        'display_name': 'Medium base',
+        'display_name': _('Medium base'),
         'filter': create_value_filter('ICONS_STYLE', 'gnome_colors')
     },
     {
         'key': 'ICONS_DARK',
         'type': 'color',
         'fallback_key': 'BTN_FG',
-        'display_name': 'Dark stroke',
+        'display_name': _('Dark stroke'),
         'filter': create_value_filter('ICONS_STYLE', 'gnome_colors')
     },
 
     {
         'type': 'separator',
-        'display_name': 'Other options'
+        'display_name': _('Other options')
     },
     {
         'key': 'UNITY_DEFAULT_LAUNCHER_STYLE',
         'type': 'bool',
         'fallback_value': False,
-        'display_name': '(Unity) Use default launcher style'
+        'display_name': _('(Unity) Use default launcher style')
     },
 ]

--- a/po.mk
+++ b/po.mk
@@ -1,0 +1,52 @@
+#!/usr/bin/make -f
+
+DOMAIN = oomox
+PODIR = po
+SOURCES = $(wildcard gui/*.py)
+LOCALEDIR = ./locale
+
+XGETTEXT ?= xgettext --package-name=$(DOMAIN) --foreign-user
+MSGINIT ?= msginit
+MSGMERGE ?= msgmerge
+MSGFMT ?= msgfmt
+RM ?= rm -f
+INSTALL ?= install
+MKDIR_P ?= mkdir -p
+
+POTFILE = $(PODIR)/$(DOMAIN).pot
+ALL_PO = $(wildcard $(PODIR)/*.po)
+ALL_MO = $(ALL_PO:.po=.mo)
+
+all: install
+
+update-pot: $(POTFILE)
+update-po: $(ALL_PO)
+
+$(POTFILE): $(SOURCES)
+	test -d $(PODIR) || $(MKDIR_P) $(PODIR)
+	$(XGETTEXT) -o $@ $^
+
+$(PODIR)/%.po: $(POTFILE)
+	if test -f $@; then \
+		$(MSGMERGE) -U $@ $(POTFILE); \
+	else \
+		$(MSGINIT) -o $@ -i $(POTFILE); \
+	fi
+
+$(PODIR)/%.mo: $(PODIR)/%.po
+	$(MSGFMT) -o $@ $^
+
+install: $(ALL_MO)
+	for f in $^; do \
+		l="$$(basename "$$f" .mo)"; \
+		d="$(LOCALEDIR)/$$l/LC_MESSAGES"; \
+		$(MKDIR_P) "$$d" || exit; \
+		$(INSTALL) -m 644 "$$f" "$$d/$(DOMAIN).mo"; \
+	done
+
+check: $(ALL_PO)
+	$(MSGFMT) --check --check-accelerators=_ --statistics $^
+
+clean:
+	$(RM) $(POTFILE)
+	$(RM) $(PODIR)/*.mo

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,0 +1,352 @@
+# French translations for oomox package
+# Traductions françaises du paquet oomox.
+# This file is put in the public domain.
+# Colomban Wendling <cwendling@hypra.fr>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: oomox\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-01 17:35+0100\n"
+"PO-Revision-Date: 2017-03-01 16:39+0100\n"
+"Last-Translator: Colomban Wendling <cwendling@hypra.fr>\n"
+"Language-Team: French\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: gui/export.py:22
+msgid "Something went wrong :("
+msgstr "Quelque chose s'est mal passé :("
+
+#: gui/export.py:26
+msgid "Dismiss"
+msgstr "Fermer"
+
+#: gui/export.py:39
+msgid "Exporting..."
+msgstr "Exportation…"
+
+#: gui/export.py:44
+msgid ""
+"Please wait while\n"
+"new colorscheme will be created"
+msgstr ""
+"Veuillez patienter pendant que\n"
+"le nouveau thème de couleur est créé"
+
+#: gui/export.py:198
+msgid "Theme applied successfully"
+msgstr "Thème appliqué avec succès"
+
+#: gui/export.py:200
+msgid "OK"
+msgstr "OK"
+
+#: gui/export.py:207
+msgid "Spotify options"
+msgstr "Options de Spotify"
+
+#: gui/export.py:212
+msgid "This functionality is still in BETA"
+msgstr "Cette fonctionnalité est encore EXPÉRIMENTALE"
+
+#: gui/export.py:219
+msgid "Normalize font weight"
+msgstr "Normaliser la graisse des polices"
+
+#: gui/export.py:223
+msgid "Spotify path:"
+msgstr "Chemin de Spotify :"
+
+#: gui/export.py:231
+msgid "Apply"
+msgstr "Appliquer"
+
+#: gui/colors_list.py:165
+msgid "Choose a color..."
+msgstr "Sélectionner une couleur…"
+
+#: gui/colors_list.py:305
+msgid "Can't be edited in GUI"
+msgstr "Ne peut pas être édité dans l'interface"
+
+#: gui/colors_list.py:366
+msgid "Edit:"
+msgstr "Éditer :"
+
+#: gui/main.py:39
+msgid "New theme"
+msgstr "Nouveau thème"
+
+#: gui/main.py:40
+msgid "Please input new theme name:"
+msgstr "Veuillez entrer le nom du nouveau thème :"
+
+#: gui/main.py:53
+msgid "_Cancel"
+msgstr "_Annuler"
+
+#: gui/main.py:54
+msgid "_OK"
+msgstr "_OK"
+
+#: gui/main.py:64 gui/main.py:303
+msgid "Rename theme"
+msgstr "Renommer le thème"
+
+#: gui/main.py:74
+msgid "Are you sure?"
+msgstr "Êtes-vous sûr ?"
+
+#: gui/main.py:83
+msgid "_No"
+msgstr "_Non"
+
+#: gui/main.py:84
+msgid "_Yes"
+msgstr "_Oui"
+
+#: gui/main.py:95
+msgid "Unsaved changes"
+msgstr "Changements non enregistrés"
+
+#: gui/main.py:96
+msgid ""
+"There are unsaved changes.\n"
+"Save them?"
+msgstr ""
+"Il y a des changements non enregistrés.\n"
+"Faut-il les sauvegarder?"
+
+#: gui/main.py:103 gui/main.py:309
+msgid "Remove theme"
+msgstr "Supprimer le thème"
+
+#: gui/main.py:104
+msgid ""
+"Are you sure you want to delete the colorscheme?\n"
+"This can not be undone."
+msgstr ""
+"Êtes-vous sûr de vouloir supprimer le thème de couleurs ?\n"
+"Cela ne peut pas être annulé."
+
+#: gui/main.py:192
+msgid "Colorscheme with such name already exists"
+msgstr "Un thème de couleurs de ce nom existe déjà"
+
+#: gui/main.py:286 gui/main.py:378
+msgid "Oo-mox GUI"
+msgstr "Interface Oo-mox"
+
+#: gui/main.py:293
+msgid "Clone current theme"
+msgstr "Cloner le thème courant"
+
+#: gui/main.py:297
+msgid "Save theme"
+msgstr "Enregistrer le thème"
+
+#: gui/main.py:321
+msgid "Apply Spotif_y theme"
+msgstr "Appliquer le thème Spotif_y"
+
+#: gui/main.py:332
+msgid "Export _icons"
+msgstr "Exporter les _icônes"
+
+#: gui/main.py:334
+msgid "Export icon theme"
+msgstr "Exporter le thème d'icônes"
+
+#: gui/main.py:338
+msgid "_Export theme"
+msgstr "_Exporter le thème"
+
+#: gui/main.py:340
+msgid "Export GTK theme"
+msgstr "Exporter le thème GTK"
+
+#: gui/theme_model.py:11
+msgid "Background"
+msgstr "Arrière-plan"
+
+#: gui/theme_model.py:16
+msgid "Foreground/text"
+msgstr "Avant-plan/texte"
+
+#: gui/theme_model.py:21
+msgid "Menu/toolbar background"
+msgstr "Arrière-plan menu/barre d'outils"
+
+#: gui/theme_model.py:26
+msgid "Menu/toolbar text"
+msgstr "Texte menu/barre d'outils"
+
+#: gui/theme_model.py:31
+msgid "Selection highlight"
+msgstr "Surlignage de la sélection"
+
+#: gui/theme_model.py:36
+msgid "Selection text"
+msgstr "Texte de la sélection"
+
+#: gui/theme_model.py:41
+msgid "Textbox background"
+msgstr "Arrière-plan zone de texte"
+
+#: gui/theme_model.py:46
+msgid "Textbox text"
+msgstr "Zone de texte"
+
+#: gui/theme_model.py:51
+msgid "Button background"
+msgstr "Arrière-plan bouton"
+
+#: gui/theme_model.py:56
+msgid "Button text"
+msgstr "Texte des boutons"
+
+#: gui/theme_model.py:62
+msgid "Header button background"
+msgstr "Arrière-plan bouton d'en-tête"
+
+#: gui/theme_model.py:68
+msgid "Header button text"
+msgstr "Texte des boutons d'en-tête"
+
+#: gui/theme_model.py:74
+msgid "Focused window border"
+msgstr "Bordure de fenêtre focusée"
+
+#: gui/theme_model.py:80
+msgid "Unfocused window border"
+msgstr "Bordure de fenêtre non focusée"
+
+#: gui/theme_model.py:85
+msgid "Theme options"
+msgstr "Options du thème"
+
+#: gui/theme_model.py:92
+msgid "Roundness"
+msgstr "Arrondi"
+
+#: gui/theme_model.py:98
+msgid "(GTK3) Spacing"
+msgstr "(GTK3) Espacement"
+
+#: gui/theme_model.py:104
+msgid "(GTK3) Gradient"
+msgstr "(GTK3) Dégradé"
+
+#: gui/theme_model.py:110
+msgid "(GTK3) Add dark variant"
+msgstr "(GTK3) Ajouter une variante sombre"
+
+#: gui/theme_model.py:116
+msgid "(GTK2) HiDPI"
+msgstr "(GTK2) HiDPI"
+
+#: gui/theme_model.py:121
+msgid "Text input caret"
+msgstr "Point d'insertion"
+
+#: gui/theme_model.py:127
+msgid "Primary caret color"
+msgstr "Couleur primaire"
+
+#: gui/theme_model.py:133
+msgid "Secondary caret color"
+msgstr "Couleur secondaire"
+
+#: gui/theme_model.py:139
+msgid "Caret aspect ratio"
+msgstr "Rapport d'aspect"
+
+#: gui/theme_model.py:144
+msgid "Iconset"
+msgstr "Thème d'icônes"
+
+#: gui/theme_model.py:160
+msgid "Icons style"
+msgstr "Style des icônes"
+
+#: gui/theme_model.py:166
+msgid "Icons color"
+msgstr "Couleur des icônes"
+
+#: gui/theme_model.py:173
+msgid "Light base (folders)"
+msgstr "Base claire (dossiers)"
+
+#: gui/theme_model.py:180
+msgid "Light base"
+msgstr "Base claire"
+
+#: gui/theme_model.py:187
+msgid "Medium base"
+msgstr "Base moyenne"
+
+#: gui/theme_model.py:194
+msgid "Dark stroke"
+msgstr "Trait sombre"
+
+#: gui/theme_model.py:200
+msgid "Other options"
+msgstr "Autres options"
+
+#: gui/theme_model.py:206
+msgid "(Unity) Use default launcher style"
+msgstr "(Unity) Utiliser le style de lanceur par défaut"
+
+#: gui/presets_list.py:112
+msgid "Presets:"
+msgstr "Préréglages :"
+
+#: gui/preview.py:264
+#, python-brace-format
+msgid "Item {id}"
+msgstr "Élément {id}"
+
+#: gui/preview.py:264
+#, python-brace-format
+msgid "Insensitive Item {id}"
+msgstr "Élément insensitif {id}"
+
+#: gui/preview.py:273
+msgid "Preview:"
+msgstr "Aperçu :"
+
+#: gui/preview.py:283
+msgid "Headerbar"
+msgstr "Barre d'en-tête"
+
+#: gui/preview.py:284
+msgid "Button"
+msgstr "Bouton"
+
+#: gui/preview.py:288
+msgid "File"
+msgstr "Fichier"
+
+#: gui/preview.py:291
+msgid "Edit"
+msgstr "Éditer"
+
+#: gui/preview.py:298
+msgid "This is a label."
+msgstr "Ceci est un label."
+
+#: gui/preview.py:299
+msgid "Selected item."
+msgstr "Élément sélectionné"
+
+#: gui/preview.py:300
+msgid "Text entry."
+msgstr "Zone de texte."
+
+#: gui/preview.py:302
+msgid "Click-click"
+msgstr "Click-click"


### PR DESCRIPTION
Add i18n support (using gettext module) and an initial French translation.

`po.mk` might need to be enhanced, because although now it's nicely automatic, it might be annoying to update the `.po` automatically when the Python sources changes (well, when running `po.mk install`, which is the default), as the `.po` are checked in source yet partially generated and containing source references, and thus can lead to extra diff.  Not 100% sure what the best thing would be here… probably the same but not automatically rebuilding the `.po` when sources changes, but only with the `update-po` target.

Also, it could also be interesting to translate scripts at some point, which is totally doable using gettext, and should be straightforward to add to this infrastructure.