### PR TITLE
doc(readme): add Fedora Copr instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Gnome-Colors and Archdroid icon themes.
 
   * [Arch Linux](#arch-linux "")
   * [Ubuntu](#ubuntu "")
+  * [Fedora](#fedora "")
   * [Other distributions](#other-distributions "")
   * [Using with tiling WMs](#using-with-tiling-wms "")
   * [Spotify](#spotify "")
@@ -51,6 +52,16 @@ For older Ubuntu releases install the dependencies manually and next follow gene
 ```
 sudo apt install ruby libgdk-pixbuf2.0-dev libxml2-utils python3-gi gtk2-engines-murrine
 sudo gem install sass
+```
+
+
+
+### Fedora
+
+Fedora 24 and 25 users users can install Oomox by using a third party copr repository:
+```bash
+sudo dnf copr enable tcg/themes
+sudo dnf install oomox
 ```
 
 


### PR DESCRIPTION
I just created a repository on [Fedora Copr](https://copr.fedorainfracloud.org/) and put an [oomox package](https://copr.fedorainfracloud.org/coprs/tcg/themes/packages/) on it. It's available for Fedora 24 and 25 users in just two commands, so I thought mentioning it in the README could be helpful for other Fedora users.