### PR TITLE
[FIX] make compatible with non-Linux (tested on FreeBSD)

### DIFF
--- a/archdroid.sh
+++ b/archdroid.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
-root="$(readlink -e $(dirname "$0"))"
+root="$(readlink -f $(dirname "$0"))"
 
 
 print_usage() {

--- a/change_color.sh
+++ b/change_color.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ue
-SRC_PATH=$(readlink -e $(dirname $0))
+SRC_PATH=$(readlink -f $(dirname $0))
 
 darker () {
 	"${SRC_PATH}/scripts/darker.sh" $@
@@ -54,14 +54,14 @@ if [[ -z "${THEME:-}" ]] ; then
 fi
 
 PATHLIST=(
-	'./src/openbox-3/'
-	'./src/assets/'
-	'./src/gtk-2.0/'
-	'./src/gtk-3.0/'
-	'./src/gtk-3.20/'
-	'./src/xfwm4/'
-	'./src/metacity-1/'
-	'./src/unity/'
+	'./src/openbox-3'
+	'./src/assets'
+	'./src/gtk-2.0'
+	'./src/gtk-3.0'
+	'./src/gtk-3.20'
+	'./src/xfwm4'
+	'./src/metacity-1'
+	'./src/unity'
 	'Makefile'
 	'./src/index.theme'
 	'./src/qt5ct_palette.conf'
@@ -134,7 +134,7 @@ done
 
 cd "$DEST_PATH"
 for FILEPATH in "${PATHLIST[@]}"; do
-	find $(echo "${FILEPATH}" | sed 's/src\///g' ) -type f -exec sed -i \
+	find $(echo "${FILEPATH}" | sed -e 's/src\///g' ) -type f -exec sed -i'' \
 		-e 's/%BG%/'"$BG"'/g' \
 		-e 's/%FG%/'"$FG"'/g' \
 		-e 's/%SEL_BG%/'"$SEL_BG"'/g' \

--- a/colors/xresources
+++ b/colors/xresources
@@ -1,4 +1,4 @@
-root="$(readlink -e $(dirname "$0"))"
+root="$(readlink -f $(dirname "$0"))"
 darker() {
 	${root}/scripts/darker.sh $@
 }

--- a/gnome_colors.sh
+++ b/gnome_colors.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
-root="$(readlink -e $(dirname "$0"))"
+root="$(readlink -f $(dirname "$0"))"
 
 
 print_usage() {

--- a/oomoxify.sh
+++ b/oomoxify.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
 
-root="$(readlink -e $(dirname "$0"))"
+root="$(readlink -f $(dirname "$0"))"
 SRC_PATH=${root}
 
 

--- a/scripts/darker.sh
+++ b/scripts/darker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -x
 
 darker_channel() {

--- a/scripts/hex_to_rgba.sh
+++ b/scripts/hex_to_rgba.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -x
 
 hextoi() {

--- a/scripts/is_dark.sh
+++ b/scripts/is_dark.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -x
 
-script_dir=$(readlink -e $(dirname "${0}"))
+script_dir=$(readlink -f $(dirname "${0}"))
 
 is_dark() {
 	hexinput=$(echo $1 | tr '[:lower:]' '[:upper:]')

--- a/scripts/mix.sh
+++ b/scripts/mix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -x
 
 mix_channel() {

--- a/scripts/render-assets.sh
+++ b/scripts/render-assets.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 do_install() {
 	local GTKDIR GTK320DIR GTKVER INSTALL_DIR

--- a/src/assets/change_dpi.sh
+++ b/src/assets/change_dpi.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 for f in $@; do
 	rsvg-convert -d 300 -p 300 -f svg $f -o $f.bak ; mv $f.bak $f
 done


### PR DESCRIPTION
This PR makes things compatible with non-Linux systems, more specifically FreeBSD (but I expect other BSDs and/or Solaris to require these changes, as well).

The changes:
  * don't expect bash to bin in /bin, look for it with env
  * `readlink -e` is not universally supported, but `readlink -f` is
  *  `sed -i` needs a backup suffix for non-gnu sed.
  * the default behaviour for `cp -r FOO/` is to copy the contents of FOO, not the FOO directory so I removed trailing / in the PATHLIST

I haven't checked the effect of the changes on Linux, but I am *rather* sure they should have no effect