### PR TITLE
switch from pacaur to trizen

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Other topics:
 #### Install
 
 ```
-pacaur -S oomox-git
+trizen -S oomox-git
 ```
 
 #### Open the GUI


### PR DESCRIPTION
pacaur is no longer maintained (https://github.com/rmarquis/pacaur) 

trizen is a good replacement because it has the same syntax as pacaur.