### PR TITLE
Mark optional dependencies as such for packaging

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -42,11 +42,8 @@ depends=(
 	'gtk-engine-murrine'
 	'gtk-engines'
 	'polkit'
-	'parallel'
-	'optipng'
 	'librsvg'
 	'imagemagick'
-	'inkscape'
 )
 makedepends=(
 	'git'
@@ -55,6 +52,9 @@ optdepends=(
 	'xorg-xrdb: for the `xresources` theme'
 	'breeze-icons: more fallback icons'
 	'gksu: for applying Spotify theme from GUI without polkit'
+	'parallel: for Materia theme'
+	'optipng: for Materia theme'
+	'inkscape: for Materia theme'
 )
 options=(
 	'!strip'

--- a/packaging/ubuntu/control
+++ b/packaging/ubuntu/control
@@ -2,7 +2,8 @@ Package: oomox
 Version: 1.4.99-1~actionless~zesty
 Architecture: all
 Maintainer: Yauheni Kirylau <actionless.loveless@gmail.com>
-Depends: python3-gi, libglib2.0-bin, libgdk-pixbuf2.0-dev, libxml2-utils, x11-xserver-utils, gir1.2-gtk-3.0, gir1.2-glib-2.0, gir1.2-pango-1.0, gir1.2-gdkpixbuf-2.0, gtk2-engines, gtk2-engines-murrine, gtk2-engines-pixbuf, bash, bc, sed, grep, parallel, sassc, imagemagick, optipng, librsvg2-bin, inkscape
+Depends: python3-gi, libglib2.0-bin, libgdk-pixbuf2.0-dev, libxml2-utils, x11-xserver-utils, gir1.2-gtk-3.0, gir1.2-glib-2.0, gir1.2-pango-1.0, gir1.2-gdkpixbuf-2.0, gtk2-engines, gtk2-engines-murrine, gtk2-engines-pixbuf, bash, bc, sed, grep, sassc, imagemagick, librsvg2-bin
+Recommends: parallel, optipng, inkscape
 Suggests: breeze-icon-theme
 Section: devel
 Priority: optional


### PR DESCRIPTION
Some dependencies are marked as optional in the README, but are configured as mandatory in Ubuntu and Arch packages. Assuming the README is right, this fixes the packages.