### PR TITLE
Ubuntu Deb - specify minimum sassc (>=3.4) and libsass0 (>=3.4)

### DIFF
--- a/packaging/ubuntu/control
+++ b/packaging/ubuntu/control
@@ -2,7 +2,7 @@ Package: oomox
 Version: 1.6.0-1~actionless~zesty
 Architecture: all
 Maintainer: Yauheni Kirylau <actionless.loveless@gmail.com>
-Depends: python3-gi, libglib2.0-bin, libgdk-pixbuf2.0-dev, libxml2-utils, x11-xserver-utils, gir1.2-gtk-3.0, gir1.2-glib-2.0, gir1.2-pango-1.0, gir1.2-gdkpixbuf-2.0, gtk2-engines, gtk2-engines-murrine, gtk2-engines-pixbuf, bash, bc, sed, grep, parallel, sassc, imagemagick, optipng, librsvg2-bin, inkscape, python3-pillow
+Depends: python3-gi, libglib2.0-bin, libgdk-pixbuf2.0-dev, libxml2-utils, x11-xserver-utils, gir1.2-gtk-3.0, gir1.2-glib-2.0, gir1.2-pango-1.0, gir1.2-gdkpixbuf-2.0, gtk2-engines, gtk2-engines-murrine, gtk2-engines-pixbuf, bash, bc, sed, grep, parallel, sassc (>=3.4), libsass0 (>=3.4), imagemagick, optipng, librsvg2-bin, inkscape, python3-pillow
 Suggests: breeze-icon-theme
 Section: devel
 Priority: optional


### PR DESCRIPTION
Fixes #133 

On Ubuntu xenial based systems it was possible to install Oomox Deb with an incompatible version of libsass0 from the xenial repos which would result in Oomox GUI failing to build themes.

This commit enforces minimum versions for both sassc and libsass0

Ubuntu xenial users can source compatible versions of both packages via https://packages.ubuntu.com/bionic/sassc and https://packages.ubuntu.com/bionic/libsass0