### PR TITLE
update Arch install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Other topics:
 #### Install
 
 ```
-pikaur -S oomox-git
+git clone https://aur.archlinux.org/oomox.git
+cd oomox
+makepkg -si
 ```
 
 #### Open the GUI


### PR DESCRIPTION
## Rationale

AUR helpers are [not supported](https://wiki.archlinux.org/index.php/AUR_helpers) and do not follow Arch best practices.

## Changes

This PR updates the Arch Linux installation instructions as per [the AUR installation instructions](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages). 